### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/rohit190183107010/eb81daf1-662b-42e7-8099-648f719e4e6d/f881d089-6f80-400b-bafd-b34f00343b7b/_apis/work/boardbadge/d2fba817-5ad5-4733-bf96-833b3b385a7f)](https://dev.azure.com/rohit190183107010/eb81daf1-662b-42e7-8099-648f719e4e6d/_boards/board/t/f881d089-6f80-400b-bafd-b34f00343b7b/Microsoft.RequirementCategory)
 # myfirstrepo
 first repo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rohit190183107010/eb81daf1-662b-42e7-8099-648f719e4e6d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.